### PR TITLE
Topic data source now supports AVRO schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [master](https://github.com/Axual/terraform-provider-axual/blob/master) - TBR
 * Added `Instance` data source.
 * Added error handling for environment, group and topic datasources.
+* Added AVRO schema support to Topic data source.
+* Refactored running acceptance tests to be simpler.
 
 ## [2.4.1](https://github.com/Axual/terraform-provider-axual/releases/tag/v2.4.1) - 2024-09-23
 * Documentation improvements: Concise front page and improved Connector guide.

--- a/README.md
+++ b/README.md
@@ -153,13 +153,16 @@ go generate
     - For IntelliJ IDEA click edit configuration -> Go tool arguments
 - Make sure to turn off test caching, because then we can run the same tests multiple times to test stability without having to change the test.
   - - Use this go tool argument: `-count 1`
-- In all test .tf files replace the instance name inside the data block `data "axual_instance" "testInstance"` with the existing real instance name in your platform
+- In the file `test_config.yaml`:
+  - Replace the value of the `instanceName` with the existing real instance name in your platform.
+  - Replace the value of the `userGroup` with any group name that the logged-in user is a member of.
 - Make sure the certs in the tests match the CA for the Instance, replace them if not.
+  - Easiest way to do this is to change Instance CA to `axual-dummy-intermediate` using the UI.
+    - For Axual employees download it from here: https://gitlab.com/axual/qa/local-development/-/blob/main/governance/files/axual-dummy-intermediate
 - Make sure OAUTHBEARER auth method is turned on: in PM conf(`api.available.auth.methods`), Tenant auth method, Instance auth method
   - Needed for testing OAUTHBEARER Application Principal
 - Make sure Granular Stream Browse Permissions are turned on for the instance
   - Needed for testing Topic Browse Permissions
-- Make sure you replace `data "axual_group" "root_user_group"` with a group name that your logged-in user is a member of in files `axual_topic_browse_permissions_initial.tf` and `axual_topic_browse_permissions_updated.tf`.
 - First try to run one acceptance test, before trying to run all the tests. It might happen that if a test fails, you have to manually delete resources using UI.
   - We recommend to try to run in this order:
     - user_resource_test.go

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ The following example demonstrates the basic functionality of Axual Self-Service
 # This TerraForm file shows the basic capabilities of the TerraForm provider for Axual
 #
 # - When trying out this example:
-# - replace `instance` UID
+# - replace `instance` name from `Dev Test Acceptance` to the name of your instance.
 # - make sure that the user, group, topic and other resource names already do not exist in the environment
 
 
@@ -71,6 +71,10 @@ resource "axual_group" "tenant_admin_group" {
  ]
 }
 
+data "axual_instance" "testInstance"{
+  name = "Dev Test Acceptance" # Replace with the name of your instance
+}
+
 resource "axual_environment" "development" {
   name = "development"
   short_name = "dev"
@@ -78,7 +82,7 @@ resource "axual_environment" "development" {
   color = "#19b9be"
   visibility = "Public"
   authorization_issuer = "Auto"
-  instance = "51be2a6a5eee481198787dc346ab6608"
+  instance = data.axual_instance.testInstance.id
   owners = axual_group.tenant_admin_group.id
 }
 

--- a/examples/axual/avro-schemas/gitops_test_v1.avsc
+++ b/examples/axual/avro-schemas/gitops_test_v1.avsc
@@ -1,11 +1,11 @@
 {
   "type": "record",
-  "name": "GitOpsTest",
+  "name": "GitOpsTest1",
   "namespace": "io.axual.qa.general",
   "doc": "Object type that is supposed to be filled with a gitops test value. This should be used when the Key is irrelevant.",
   "fields": [
     {
-      "name": "gitops",
+      "name": "gitops1",
       "type": "string",
       "doc": "The gitops test value. v 1.0.0"
     }

--- a/examples/axual/main.tf
+++ b/examples/axual/main.tf
@@ -4,7 +4,7 @@
 # This TerraForm file shows the basic capabilities of the TerraForm provider for Axual
 #
 # - When trying out this example:
-# - replace `instance` UID
+# - replace `instance` name from `Dev Test Acceptance` to the name of your instance.
 # - make sure that the user, group, topic and other resource names already do not exist in the environment
 
 
@@ -30,6 +30,10 @@ resource "axual_group" "tenant_admin_group" {
  ]
 }
 
+data "axual_instance" "testInstance"{
+  name = "Dev Test Acceptance" # Replace with the name of your instance
+}
+
 resource "axual_environment" "development" {
   name = "development"
   short_name = "dev"
@@ -37,7 +41,7 @@ resource "axual_environment" "development" {
   color = "#19b9be"
   visibility = "Public"
   authorization_issuer = "Auto"
-  instance = "51be2a6a5eee481198787dc346ab6608"
+  instance = data.axual_instance.testInstance.id
   owners = axual_group.tenant_admin_group.id
 }
 

--- a/internal/provider/data_source_topic.go
+++ b/internal/provider/data_source_topic.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	webclient "axual-webclient"
+	"axual.com/terraform-provider-axual/internal/provider/utils"
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -167,24 +168,14 @@ func mapTopicDataSourceResponseToData(ctx context.Context, data *topicDataSource
 		data.Description = types.StringValue(topic.Description.(string))
 	}
 
-	// Map key_schema if KeyType is AVRO
 	if data.KeyType.ValueString() == "AVRO" {
-		if topic.Embedded.KeySchema.Uid != "" {
-			data.KeySchema = types.StringValue(topic.Embedded.KeySchema.Uid)
-		} else {
-			data.KeySchema = types.StringNull()
-		}
+		data.KeySchema = utils.SetStringValue(topic.Embedded.KeySchema.Uid)
 	} else {
 		data.KeySchema = types.StringNull()
 	}
 
-	// Map value_schema if ValueType is AVRO
 	if data.ValueType.ValueString() == "AVRO" {
-		if topic.Embedded.ValueSchema.Uid != "" {
-			data.ValueSchema = types.StringValue(topic.Embedded.ValueSchema.Uid)
-		} else {
-			data.ValueSchema = types.StringNull()
-		}
+		data.ValueSchema = utils.SetStringValue(topic.Embedded.ValueSchema.Uid)
 	} else {
 		data.ValueSchema = types.StringNull()
 	}

--- a/internal/provider/data_source_topic.go
+++ b/internal/provider/data_source_topic.go
@@ -32,7 +32,9 @@ type topicDataSourceData struct {
 	Name            types.String `tfsdk:"name"`
 	Description     types.String `tfsdk:"description"`
 	KeyType         types.String `tfsdk:"key_type"`
+	KeySchema       types.String `tfsdk:"key_schema"`
 	ValueType       types.String `tfsdk:"value_type"`
+	ValueSchema     types.String `tfsdk:"value_schema"`
 	Owners          types.String `tfsdk:"owners"`
 	RetentionPolicy types.String `tfsdk:"retention_policy"`
 	Id              types.String `tfsdk:"id"`
@@ -67,6 +69,14 @@ func (d *topicDataSource) Schema(ctx context.Context, req datasource.SchemaReque
 			},
 			"value_type": schema.StringAttribute{
 				MarkdownDescription: "The value type and reference to the schema (if applicable). Read more: https://docs.axual.io/axual/2024.2/self-service/topic-management.html#value-type",
+				Computed:            true,
+			},
+			"key_schema": schema.StringAttribute{
+				MarkdownDescription: "The key schema UID if `key_type` is 'AVRO'.",
+				Computed:            true,
+			},
+			"value_schema": schema.StringAttribute{
+				MarkdownDescription: "The value schema UID if `value_type` is 'AVRO'.",
 				Computed:            true,
 			},
 			"owners": schema.StringAttribute{
@@ -155,5 +165,27 @@ func mapTopicDataSourceResponseToData(ctx context.Context, data *topicDataSource
 		data.Description = types.StringNull()
 	} else {
 		data.Description = types.StringValue(topic.Description.(string))
+	}
+
+	// Map key_schema if KeyType is AVRO
+	if data.KeyType.ValueString() == "AVRO" {
+		if topic.Embedded.KeySchema.Uid != "" {
+			data.KeySchema = types.StringValue(topic.Embedded.KeySchema.Uid)
+		} else {
+			data.KeySchema = types.StringNull()
+		}
+	} else {
+		data.KeySchema = types.StringNull()
+	}
+
+	// Map value_schema if ValueType is AVRO
+	if data.ValueType.ValueString() == "AVRO" {
+		if topic.Embedded.ValueSchema.Uid != "" {
+			data.ValueSchema = types.StringValue(topic.Embedded.ValueSchema.Uid)
+		} else {
+			data.ValueSchema = types.StringNull()
+		}
+	} else {
+		data.ValueSchema = types.StringNull()
 	}
 }

--- a/internal/provider/resource_topic.go
+++ b/internal/provider/resource_topic.go
@@ -3,6 +3,7 @@ package provider
 import (
 	webclient "axual-webclient"
 	custom_validator "axual.com/terraform-provider-axual/internal/custom-validator"
+	"axual.com/terraform-provider-axual/internal/provider/utils"
 	"context"
 	"errors"
 	"fmt"
@@ -371,16 +372,14 @@ func mapTopicResponseToData(ctx context.Context, data *topicResourceData, topic 
 		}
 	}
 
-	// Map key_schema
-	if topic.Embedded.KeySchema.Uid != "" {
-		data.KeySchema = types.StringValue(topic.Embedded.KeySchema.Uid)
+	if data.KeyType.ValueString() == "AVRO" {
+		data.KeySchema = utils.SetStringValue(topic.Embedded.KeySchema.Uid)
 	} else {
 		data.KeySchema = types.StringNull()
 	}
 
-	// Map value_schema
-	if topic.Embedded.ValueSchema.Uid != "" {
-		data.ValueSchema = types.StringValue(topic.Embedded.ValueSchema.Uid)
+	if data.ValueType.ValueString() == "AVRO" {
+		data.ValueSchema = utils.SetStringValue(topic.Embedded.ValueSchema.Uid)
 	} else {
 		data.ValueSchema = types.StringNull()
 	}

--- a/internal/provider/resource_topic.go
+++ b/internal/provider/resource_topic.go
@@ -370,4 +370,18 @@ func mapTopicResponseToData(ctx context.Context, data *topicResourceData, topic 
 			tflog.Error(ctx, "Error creating viewers set", errorDetails)
 		}
 	}
+
+	// Map key_schema
+	if topic.Embedded.KeySchema.Uid != "" {
+		data.KeySchema = types.StringValue(topic.Embedded.KeySchema.Uid)
+	} else {
+		data.KeySchema = types.StringNull()
+	}
+
+	// Map value_schema
+	if topic.Embedded.ValueSchema.Uid != "" {
+		data.ValueSchema = types.StringValue(topic.Embedded.ValueSchema.Uid)
+	} else {
+		data.ValueSchema = types.StringNull()
+	}
 }

--- a/internal/provider/utils/utils.go
+++ b/internal/provider/utils/utils.go
@@ -1,0 +1,11 @@
+package utils
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// Helper function to set a Terraform string value or null based on input
+func SetStringValue(input string) types.String {
+	if input != "" {
+		return types.StringValue(input)
+	}
+	return types.StringNull()
+}

--- a/internal/tests/ApplicationAccessGrantDataSource/axual_application_access_grant.tf
+++ b/internal/tests/ApplicationAccessGrantDataSource/axual_application_access_grant.tf
@@ -47,10 +47,6 @@ resource "axual_topic" "topic-test" {
   description = "Demo of deploying a topic config via Terraform"
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationAccessGrantResource/axual_application_access_grant_auto_approval.tf
+++ b/internal/tests/ApplicationAccessGrantResource/axual_application_access_grant_auto_approval.tf
@@ -55,10 +55,6 @@ resource "axual_topic_config" "tf-topic-config" {
   properties = {"segment.ms"="600012", "retention.bytes"="-1"}
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationAccessGrantResource/axual_application_access_grant_stream_owner_approval.tf
+++ b/internal/tests/ApplicationAccessGrantResource/axual_application_access_grant_stream_owner_approval.tf
@@ -54,11 +54,6 @@ resource "axual_topic_config" "tf-topic-config" {
   environment = axual_environment.tf-test-env.id
   properties = {"segment.ms"="600012", "retention.bytes"="-1"}
 }
-
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationAccessGrantResource/axual_application_access_grant_stream_owner_rejection.tf
+++ b/internal/tests/ApplicationAccessGrantResource/axual_application_access_grant_stream_owner_rejection.tf
@@ -55,10 +55,6 @@ resource "axual_topic_config" "tf-topic-config" {
   properties = {"segment.ms"="600012", "retention.bytes"="-1"}
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationDeploymentResource/axual_application_deployment_initial.tf
+++ b/internal/tests/ApplicationDeploymentResource/axual_application_deployment_initial.tf
@@ -57,10 +57,6 @@ resource "axual_topic_config" "tf-topic-config" {
   properties = {"segment.ms"="600012", "retention.bytes"="-1"}
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationDeploymentResource/axual_application_deployment_updated.tf
+++ b/internal/tests/ApplicationDeploymentResource/axual_application_deployment_updated.tf
@@ -57,11 +57,6 @@ resource "axual_topic_config" "tf-topic-config" {
   properties = {"segment.ms"="600012", "retention.bytes"="-1"}
 }
 
-
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_connector_initial.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_connector_initial.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_connector_replaced.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_connector_replaced.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_custom_initial.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_custom_initial.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_custom_replaced.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_custom_replaced.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_oauthbearer_initial.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_oauthbearer_initial.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_oauthbearer_replaced.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_oauthbearer_replaced.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/EnvironmentDataSource/axual_environment.tf
+++ b/internal/tests/EnvironmentDataSource/axual_environment.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/EnvironmentResource/axual_environment_initial.tf
+++ b/internal/tests/EnvironmentResource/axual_environment_initial.tf
@@ -20,10 +20,6 @@ resource "axual_group" "team-integrations" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/EnvironmentResource/axual_environment_updated.tf
+++ b/internal/tests/EnvironmentResource/axual_environment_updated.tf
@@ -64,10 +64,6 @@ resource "axual_group" "team-integrations3" {
   ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development1"
   short_name = "tfdev"

--- a/internal/tests/InstanceDataSource/axual_instance_initial.tf
+++ b/internal/tests/InstanceDataSource/axual_instance_initial.tf
@@ -1,3 +1,0 @@
-data "axual_instance" "dta" {
- name = "Dev Test Acceptance"
-}

--- a/internal/tests/InstanceDataSource/axual_instance_invalid_name.tf
+++ b/internal/tests/InstanceDataSource/axual_instance_invalid_name.tf
@@ -1,3 +1,3 @@
-data "axual_instance" "testInstance" {
+data "axual_instance" "wrong_name" {
   name = "dt"
 }

--- a/internal/tests/InstanceDataSource/instance_data_source_test.go
+++ b/internal/tests/InstanceDataSource/instance_data_source_test.go
@@ -15,12 +15,9 @@ func TestInstanceDataSource(t *testing.T) {
 		ExternalProviders:        GetProviderConfig(t).ExternalProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: GetProvider() + GetFile("axual_instance_initial.tf"),
+				Config: GetProvider(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.axual_instance.dta", "name", "Dev Test Acceptance"),
-					resource.TestCheckResourceAttr("data.axual_instance.dta", "description", "Dev Test Acceptance"),
-					resource.TestCheckResourceAttr("data.axual_instance.dta", "short_name", "dta"),
-					resource.TestCheckResourceAttr("data.axual_instance.dta", "id", "4b0f204ede6542dfae6bf836f8185c5e"),
+					resource.TestCheckResourceAttr("data.axual_instance.testInstance", "name", "Dev Test Acceptance"),
 				),
 			},
 			{
@@ -33,9 +30,8 @@ func TestInstanceDataSource(t *testing.T) {
 				ExpectError: regexp.MustCompile("Attribute name string length must be between 3 and 50, got: 2"),
 			},
 			{
-				// To ensure cleanup if one of the test cases had an error
 				Destroy: true,
-				Config:  GetProvider() + GetFile("axual_instance_initial.tf"),
+				Config:  GetProvider(),
 			},
 		},
 	})

--- a/internal/tests/TopicBrowsePermissionsResource/axual_topic_browse_permissions_initial.tf
+++ b/internal/tests/TopicBrowsePermissionsResource/axual_topic_browse_permissions_initial.tf
@@ -79,14 +79,6 @@ resource "axual_group" "team-group3" {
   members       = [ axual_user.susan.id ]
 }
 
-data "axual_group" "root_user_group" {
-  name = "Kaspar test 888"
-}
-
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"
@@ -102,7 +94,7 @@ resource "axual_topic" "topic-test" {
   name = "test-topic"
   key_type = "String"
   value_type = "String"
-  owners = data.axual_group.root_user_group.id
+  owners = data.axual_group.user_group.id
   retention_policy = "delete"
   properties = {}
   description = "Demo of deploying a topic config via Terraform"

--- a/internal/tests/TopicBrowsePermissionsResource/axual_topic_browse_permissions_updated.tf
+++ b/internal/tests/TopicBrowsePermissionsResource/axual_topic_browse_permissions_updated.tf
@@ -79,14 +79,6 @@ resource "axual_group" "team-group3" {
   members       = [ axual_user.susan.id ]
 }
 
-data "axual_group" "root_user_group" {
-  name = "Kaspar test 888"
-}
-
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"
@@ -102,7 +94,7 @@ resource "axual_topic" "topic-test" {
   name = "test-topic"
   key_type = "String"
   value_type = "String"
-  owners = data.axual_group.root_user_group.id
+  owners = data.axual_group.user_group.id
   retention_policy = "delete"
   properties = {}
   description = "Demo of deploying a topic config via Terraform"

--- a/internal/tests/TopicBrowsePermissionsResource/axual_topic_browse_permissions_updated_missing_groups_users.tf
+++ b/internal/tests/TopicBrowsePermissionsResource/axual_topic_browse_permissions_updated_missing_groups_users.tf
@@ -79,14 +79,6 @@ resource "axual_group" "team-group3" {
   members       = [ axual_user.susan.id ]
 }
 
-data "axual_group" "root_user_group" {
-  name = "Kaspar test 888"
-}
-
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"
@@ -102,7 +94,7 @@ resource "axual_topic" "topic-test" {
   name = "test-topic"
   key_type = "String"
   value_type = "String"
-  owners = data.axual_group.root_user_group.id
+  owners = data.axual_group.user_group.id
   retention_policy = "delete"
   properties = {}
   description = "Demo of deploying a topic config via Terraform"

--- a/internal/tests/TopicConfigResource/axual_topic_config_avro_initial.tf
+++ b/internal/tests/TopicConfigResource/axual_topic_config_avro_initial.tf
@@ -41,10 +41,6 @@ resource "axual_schema_version" "axual_gitops_test_schema_version2_v2" {
   description = "Gitops test schema version"
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/TopicConfigResource/axual_topic_config_avro_updated.tf
+++ b/internal/tests/TopicConfigResource/axual_topic_config_avro_updated.tf
@@ -41,10 +41,6 @@ resource "axual_schema_version" "axual_gitops_test_schema_version2_v2" {
   description = "Gitops test schema version"
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/TopicConfigResource/axual_topic_config_setup.tf
+++ b/internal/tests/TopicConfigResource/axual_topic_config_setup.tf
@@ -17,10 +17,6 @@ resource "axual_group" "team-group1" {
   members       = [ axual_user.bob.id ]
 }
 
-data "axual_instance" "testInstance"{
-  name = "testInstance"
-}
-
 resource "axual_environment" "tf-test-env" {
   name = "tf-development"
   short_name = "tfdev"

--- a/internal/tests/TopicDataSource/topic_data_source_test.go
+++ b/internal/tests/TopicDataSource/topic_data_source_test.go
@@ -26,6 +26,8 @@ func TestTopicDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr("data.axual_topic.topic-test", "properties.propertyKey2", "propertyValue2"),
 					resource.TestCheckResourceAttrPair("data.axual_topic.topic-test", "owners", "axual_topic.topic-test", "owners"),
 					resource.TestCheckResourceAttrPair("data.axual_topic.topic-test", "id", "axual_topic.topic-test", "id"),
+					resource.TestCheckResourceAttrPair("data.axual_topic.topic-test", "key_schema", "axual_topic.topic-test", "key_schema"),
+					resource.TestCheckResourceAttrPair("data.axual_topic.topic-test", "value_schema", "axual_topic.topic-test", "value_schema"),
 				),
 			},
 			{

--- a/internal/tests/test_config.yaml
+++ b/internal/tests/test_config.yaml
@@ -2,3 +2,5 @@ provider:
   # Version is "local" for local provider, the binary path is in .terraformrc under "dev_overrides"
   # Version is a specific version like "2.4.1" for a public official registry version
   version: "local"
+instanceName: "Dev Test Acceptance"
+userGroup: "Team Awesome"


### PR DESCRIPTION
1. Topic data source now supports AVRO schemas
2. Previously if someone wanted to run all tests they had to change 19 different files for instance name and user's group name. Now they only have to change 1 file `test_config.yaml`.