### PR TITLE
Wait 4 seconds when stopping the connector

### DIFF
--- a/axual-webclient/application_deployment.go
+++ b/axual-webclient/application_deployment.go
@@ -76,7 +76,12 @@ func (c *Client) OperateApplicationDeployment(id string, action string, data App
 	if err != nil {
 		return err
 	}
-	time.Sleep(2 * time.Second) //to give time for Connect/Kafka to propagate changes
+	// To give time for Connect/Kafka to propagate changes
+	if action == "STOP" {
+		time.Sleep(4 * time.Second) // 4-second delay for STOP action
+	} else {
+		time.Sleep(2 * time.Second) // 2-second delay for other actions
+	}
 	return nil
 }
 


### PR DESCRIPTION
Wait 4 seconds when stopping the connector to give Platform Manager time to propagate the request to Connect server.