### PR TITLE
Add responsible disclosure instructions.

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Reporting Security Issues
+
+The Axual team and community take security bugs in Axual Terraform Provider, and underlying libraries, seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please *DO NOT* create a public issue but instead, send an email to security@axual.com including the version number of the Axual Terraform Provider used including details on the vulnerability discovered. Include screenshots if those help to clarify the issue.
+
+The Axual security team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+


### PR DESCRIPTION
Add instructions on how to responsibly disclose security vulnerabilities in the provider (or underlying components).