### PR TITLE
Topic Config Create Crash fix

### DIFF
--- a/axual-webclient/client.go
+++ b/axual-webclient/client.go
@@ -59,6 +59,13 @@ func (c *Client) doRequest(req *http.Request) ([]byte, error) {
 	}
 
 	res, err := c.HTTPClient.Do(req)
+	if err != nil {
+		log.Printf("Network error during HTTP request: %v", err)
+		return nil, err
+	}
+	if res == nil {
+		return nil, fmt.Errorf("received nil response from HTTP client")
+	}
 	if res.StatusCode == http.StatusNotFound {
 		return nil, NotFoundError
 	}


### PR DESCRIPTION
The crash happened because:

- In doRequest function we immediately access res.StatusCode after calling c.HTTPClient.Do(req) without first checking if an error occurred. If the API call fails (for example, due to a timeout), c.HTTPClient.Do(req) can return a non-nil error and a nil response. Then when we try to read res.StatusCode, we end up with a nil pointer dereference, which causes the panic.