### PR TITLE
Enforce lowercase application name

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -79,7 +79,7 @@ func (r *applicationResource) Schema(ctx context.Context, req resource.SchemaReq
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.LengthBetween(3, 60),
-					stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_]*$`), "can only contain letters, numbers, and underscores and cannot begin with an underscore"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z0-9][a-z0-9_]*$`), "can only contain lowercase letters, numbers, and underscores and cannot begin with an underscore"),
 				},
 			},
 			"owners": schema.StringAttribute{

--- a/internal/tests/ApplicationResource/application_resource_test.go
+++ b/internal/tests/ApplicationResource/application_resource_test.go
@@ -2,6 +2,7 @@ package ApplicationResource
 
 import (
 	. "axual.com/terraform-provider-axual/internal/tests"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -38,6 +39,10 @@ func TestApplicationResource(t *testing.T) {
 					resource.TestCheckResourceAttr("axual_application.tf-test-app", "visibility", "Private"),
 					resource.TestCheckResourceAttr("axual_application.tf-test-app", "description", "Axual's TF Test Application1"),
 				),
+			},
+			{
+				Config: GetProvider() + GetFile("axual_application_invalid_uppercase.tf"),
+				ExpectError: regexp.MustCompile(`can only contain lowercase letters, numbers, and\s+underscores and cannot begin with an underscore`),
 			},
 			{
 				ResourceName:      "axual_application.tf-test-app",

--- a/internal/tests/ApplicationResource/axual_application_invalid_uppercase.tf
+++ b/internal/tests/ApplicationResource/axual_application_invalid_uppercase.tf
@@ -1,0 +1,10 @@
+resource "axual_application" "tf-test-app" {
+    name             = "tf-test app"
+    application_type = "Custom"
+    short_name       = "TF_Test_App"  # Mixed case - should fail
+    application_id   = "tf.test.app"
+    owners           = data.axual_group.test_group.id
+    type             = "Java"
+    visibility       = "Public"
+    description      = "Axual's TF Test Application"
+  }


### PR DESCRIPTION
Added validation for the application shortName to only accept lowercase alphabets