### PR TITLE
docs: Refactor documentation to separate user and developer audiences

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,10 +11,10 @@ Please note we have a code of conduct, please follow it in all your interactions
 2. Document your code appropriately.
 3. Code coverage should meet the expected 70%.
 4. Bugfixes should include a unit test or integration test reproducing the issue.
-5. Try to keep merge request short and submit separate ones for unrelated features, but feel 
+5. Try to keep the merge request short and submit separate ones for unrelated features, but feel 
 free to combine simple bugfixes/tests into one merge request.
 6. Update the [`README.md`](README.md) if necessary with details of changes to the interface, 
-this includes new environment variables, useful file locations etc.
+this includes new environment variables, useful file locations, etc.
 7. You may merge the merge request in once you have the sign-off of two other developers, or 
 if you do not have permission to do that, you may request the second reviewer to merge it for you.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -347,11 +347,3 @@ To debug acceptance tests in IntelliJ IDEA:
 3. Click the Debug button
 
 **Note:** Debugging only works with a locally compiled provider, not when using a provider from the registry.
-
-## Contributing
-
-We welcome contributions! Please ensure:
-- All tests pass before submitting a pull request
-- New features include appropriate tests
-- Documentation is generated with `go generate` if schema changes are made
-- Code follows Go best practices and existing project patterns

--- a/README.md
+++ b/README.md
@@ -204,4 +204,4 @@ For issues, questions, or feature requests, please open an issue in this reposit
 
 ## License
 
-See [LICENSE](LICENSE) for details.
+See [LICENSE](LICENSE.txt) for details.

--- a/README.md
+++ b/README.md
@@ -1,139 +1,97 @@
-## Terraform Provider development
+# Terraform Provider for Axual Platform
 
-Prerequisites
-- Install terraform
-  - Recommended approach: `brew install terraform`
-- Install golang
-  - Recommended approach: `brew install go`
+The Terraform Provider for Axual Platform allows you to manage Axual resources through Terraform, including applications, topics, schemas, environments, users, and groups.
 
+## Requirements
 
-Create the file `~/.terraformrc` and add the following to make the provider local installation work:
-This points to the locally compiled Terraform Provider on your computer.
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
+- Access to an Axual Platform instance (local deployment or Axual Cloud)
 
-Replace `<user>` with the correct username.
+## Using the Provider
 
-```shell
-provider_installation {
+### Installation
 
-  dev_overrides {
-      "axual.com/hackz/axual" = "/Users/<user>/go/bin"
-  }
-
-  # For all other providers, install them directly from their origin provider
-  # registries as normal. If you omit this, Terraform will _only_ use
-  # the dev_overrides block, and so no other providers will be available.
-  direct {}
-}
-```
-
-Go to `terraform-provider-axual` directory and run `go mod tidy`. 
-This will download the libraries.
-
-Then run `go install` in terraform-provider-axual directory
-(or `go build -o $GOPATH/bin/`) to install the provider locally. 
-The provider gets installed in `$GOPATH/bin` directory.
-
-Now you can go to `terraform-provider-axual/examples/axual`.
-
-Open the `provider.tf` file and refer to this local binary and provide your configuration.
+The provider is available on the [Terraform Registry](https://registry.terraform.io/). Add it to your Terraform configuration:
 
 ```terraform
 terraform {
   required_providers {
     axual = {
-      source  = "axual.com/hackz/axual"
+      source  = "axual/axual"
+      version = "~> 2.6"
     }
   }
 }
+```
 
-# PROVIDER CONFIGURATION
-#
-# Below example configuration is for when you have deployed Axual Platform locally.
+### Provider Configuration
 
+#### Local Axual Platform
+
+Configure the provider to connect to a locally deployed Axual Platform instance:
+
+```terraform
 provider "axual" {
   apiurl   = "https://platform.local/api"
   realm    = "axual"
-  username = "kubernetes@axual.com"   #- or set using env property export AXUAL_AUTH_USERNAME=
-  password = "PLEASE_CHANGE_PASSWORD" #- or set using env property export AXUAL_AUTH_PASSWORD=
+  username = "kubernetes@axual.com"   # or set using env: AXUAL_AUTH_USERNAME
+  password = "PLEASE_CHANGE_PASSWORD" # or set using env: AXUAL_AUTH_PASSWORD
   clientid = "self-service"
   authurl  = "https://platform.local/auth/realms/axual/protocol/openid-connect/token"
   scopes   = ["openid", "profile", "email"]
 }
+```
 
-# Below example configuration is for when you have deployed Axual Platform in Axual Cloud.
+#### Axual Cloud
 
-# provider "axual" {
+Configure the provider to connect to Axual Cloud:
+
+```terraform
+provider "axual" {
   apiurl   = "https://axual.cloud/api"
-  realm    = "PLEASE_CHANGE_REALM"
-  username = "PLEASE_CHANGE_USERNAME"
-  password = "PLEASE_CHANGE_PASSWORD"
+  realm    = "YOUR_REALM_NAME"
+  username = "YOUR_USERNAME"
+  password = "YOUR_PASSWORD"
   clientid = "self-service"
-  authurl = "https://axual.cloud/auth/realms/PLEASE_CHANGE_REALM/protocol/openid-connect/token"
-  scopes = ["openid", "profile", "email"]
-# }
+  authurl  = "https://axual.cloud/auth/realms/YOUR_REALM_NAME/protocol/openid-connect/token"
+  scopes   = ["openid", "profile", "email"]
+}
 ```
 
-Now you can run `terraform plan` to test the provider.
-> Note you don't need to run `terraform init`.
-> 
-### Troubleshooting
-Usually if Go is installed with brew, you don't need to set any environment variables,
-but just in case things are not working, you can try the setting below in `~/.zshrc`.
+### Authentication
 
-```shell
-export GOPATH=$HOME/go
-export GOROOT=“$(brew --prefix golang)/libexec”
-export PATH=“$PATH:${GOPATH}/bin:${GOROOT}/bin”
+The provider supports authentication via:
+- Direct credentials in the provider block
+- Environment variables: `AXUAL_AUTH_USERNAME` and `AXUAL_AUTH_PASSWORD`
+
+### Example Usage
+
+After configuring the provider, initialize and apply your Terraform configuration:
+
+```bash
+terraform init
+terraform plan
+terraform apply
 ```
 
-## Terraform Documentation
+For more examples, see the `examples/` directory in this repository.
 
+## Documentation
 
-### Generate
+Full provider documentation, including all available resources and data sources, is available on the [Terraform Registry](https://registry.terraform.io/).
 
-- To generate documentation, run this command in the terraform-provider-axual directory
-```shell
-go generate
-```
-- This command generates documentation based on the templates in the templates' directory and the MarkdownDescription available in the resources schema..
+## Contributing
 
-## Terraform Manifest file(terraform-registry-manifest.json)
+Contributions are welcome! If you'd like to contribute to the development of this provider, please see [DEVELOPERS.md](DEVELOPERS.md) for information on:
+- Setting up a local development environment
+- Building the provider from source
+- Running tests
+- Debugging
 
-- **version** is the numeric version of the manifest format, not the version of our provider.
-- **protocol_versions** is the Terraform protocol version. This is set to 6.0 because we are using Terraform Plugin Framework to develop our provider.
+## Support
 
-## Debugging in IntelliJ IDEA using Delve
-- There are four IntelliJ IDEA run configurations in `.run` folder. Open IntelliJ run configuration menu to see them.
-- Steps to debug Terraform Provider
-  - brew install delve
-  - Run "Axual build to _bin" to generate executable in `/go/bin` and name it terraform-provider-axual
-  - Run "Axual Delve binary" (Run icon) to start Delve's debugging session on this binary. It looks for terraform-provider-axual executable in `/go/bin`.
-  - Run "Axual Go Remote" (Debug icon) to connect IntelliJ to the Delve's debugging session. On the console you will see a string: TF_REATTACH_PROVIDERS='{"axual...
-  - Copy this string and use it as environment variable: export TF_REATTACH_PROVIDERS='{"axual...
-    - For some reason, it only works in a separate terminal session on MacOS. Also run terraform commands from the same iTerm terminal session.
-  - Set a breakpoint and run a command to run the provider like: tf plan or tf apply. It will stop at the breakpoint
-  - When done with debugging, remove the env variable: unset TF_REATTACH_PROVIDERS
-  - To do the same without generating the binary: Run "Axual Delve project" (Run icon)
+For issues, questions, or feature requests, please open an issue in this repository.
 
+## License
 
-## Debugging webclient
-- The module axual-webclient-exec is used to test and debug axual-webclient module without any Terraform functionality.
-
-## Logging
-- Logging in axual-webclient:
-  - log.Println using the module "log"
-  - For example:
-    - log.Println("strings.NewReader(string(marshal))", strings.NewReader(string(marshal)))
-- Logging in internal folder:
-  - tflog.Debug(or Info,Trace, etc)
-  - Then run TF_LOG=DEBUG(Or INFO,TRACE,ERROR) terraform plan
-  - For example:
-    - marshal, err := json.Marshal(ApplicationRequest)
-    - tflog.Error(ctx, "MARSHAL", map[string]interface{}{
-      "MARSHAL": string(marshal),
-      })
-    - Run: TF_LOG=ERROR terraform apply -auto-approve
-
-## Acceptance tests
-
-- Please read how to run tests from `DEVELOPERS.md`
+See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,117 @@ The provider supports authentication via:
 
 ### Example Usage
 
-After configuring the provider, initialize and apply your Terraform configuration:
+Here's a complete example that creates a group, environment, application, topic, and access grant:
+
+```terraform
+terraform {
+  required_providers {
+    axual = {
+      source  = "axual/axual"
+      version = "~> 2.6"
+    }
+  }
+}
+
+provider "axual" {
+  apiurl   = "https://platform.local/api"
+  realm    = "axual"
+  username = "kubernetes@axual.com"
+  password = "PLEASE_CHANGE_PASSWORD"
+  clientid = "self-service"
+  authurl  = "https://platform.local/auth/realms/axual/protocol/openid-connect/token"
+  scopes   = ["openid", "profile", "email"]
+}
+
+# Look up existing user
+data "axual_user" "my-user" {
+  email = "your.email@example.com"
+}
+
+# Look up existing instance
+data "axual_instance" "my-instance" {
+  short_name = "dev"
+}
+
+# Create a group
+resource "axual_group" "developers" {
+  name    = "Development Team"
+  members = [
+    data.axual_user.my-user.id,
+  ]
+}
+
+# Create an environment
+resource "axual_environment" "development" {
+  name                   = "Development"
+  short_name             = "dev"
+  description            = "Development environment"
+  color                  = "#19b9be"
+  visibility             = "Public"
+  authorization_issuer   = "Stream owner"
+  instance               = data.axual_instance.my-instance.id
+  owners                 = axual_group.developers.id
+}
+
+# Create an application
+resource "axual_application" "my-app" {
+  name             = "My Application"
+  application_type = "Custom"
+  short_name       = "my_app"
+  application_id   = "com.example.myapp"
+  owners           = axual_group.developers.id
+  type             = "Java"
+  visibility       = "Public"
+  description      = "My streaming application"
+}
+
+# Create application principal for SSL authentication
+resource "axual_application_principal" "my-app-principal" {
+  environment = axual_environment.development.id
+  application = axual_application.my-app.id
+  principal   = file("path/to/certificate.pem")
+}
+
+# Create a topic
+resource "axual_topic" "events" {
+  name             = "my-events"
+  key_type         = "String"
+  value_type       = "String"
+  owners           = axual_group.developers.id
+  retention_policy = "delete"
+  description      = "Application events topic"
+}
+
+# Configure topic in environment
+resource "axual_topic_config" "events-dev" {
+  partitions      = 3
+  retention_time  = 864000  # 10 days
+  topic           = axual_topic.events.id
+  environment     = axual_environment.development.id
+  properties      = {
+    "segment.ms" = "600000"
+  }
+}
+
+# Grant application access to topic
+resource "axual_application_access_grant" "my-app-consume-events" {
+  application = axual_application.my-app.id
+  topic       = axual_topic.events.id
+  environment = axual_environment.development.id
+  access_type = "CONSUMER"
+  depends_on  = [
+    axual_application_principal.my-app-principal,
+    axual_topic_config.events-dev
+  ]
+}
+
+# Approve the access grant
+resource "axual_application_access_grant_approval" "approve-access" {
+  application_access_grant = axual_application_access_grant.my-app-consume-events.id
+}
+```
+
+After creating your configuration, initialize and apply:
 
 ```bash
 terraform init
@@ -74,7 +184,7 @@ terraform plan
 terraform apply
 ```
 
-For more examples, see the `examples/` directory in this repository.
+For more examples, see the [`examples/`](./examples/) directory in this repository.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

  Restructures the README.md and DEVELOPERS.md files to provide clear separation between end-user documentation and developer/contributor documentation, following Terraform provider best practices.

  ## Changes

  ### README.md (For End Users)
  - Added clear overview of the provider's purpose and capabilities
  - Simplified installation instructions with Terraform Registry reference
  - Provided separate configuration examples for local platform and Axual Cloud
  - Added comprehensive end-to-end usage example demonstrating:
    - Provider configuration
    - Data sources (user, instance lookups)
    - Resource creation (groups, environments, applications, topics)
    - Access grants and approvals
  - Added links to full documentation and DEVELOPERS.md for contributors

  ### DEVELOPERS.md (For Contributors/Developers)
  - Reorganized content into logical sections for development workflow
  - Expanded development setup instructions with clear step-by-step guidance
  - Enhanced debugging documentation for IntelliJ IDEA and Delve
  - Improved acceptance testing documentation with:
    - Detailed prerequisites and configuration steps
    - Instructions for IntelliJ IDEA, VS Code, and command line
    - Test writing best practices
    - Debugging and logging guidance
  - Added contributing guidelines

  ## Motivation

  The previous documentation mixed user-facing and developer-facing content, making it difficult for each audience to find relevant information.