### PR TITLE
fix: use findByName/findByShortName for Instance data source lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 * Allow rotating a Connector's `axual_application_principal`
 
+### Fixed
+* Retrieve an **Instance** using `findByName` or `findByShortName` endpoints instead of `findByAttributes`
+
 ## [3.0.0](https://github.com/Axual/terraform-provider-axual/releases/tag/v3.0.0) - 2026-03-24
 ### Added
 * Import support for `axual_application_principal`

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -187,6 +187,8 @@ Before running acceptance tests:
    - `authUrl`: OAuth2 token endpoint (e.g.
      `https://platform.local/auth/realms/axual/protocol/openid-connect/token`). Also shared by the
      provider block and the API check helpers.
+   - `realm`: Authentication realm (e.g. `axual`). Shared by the provider block and the API check
+     helpers. Optional — defaults to `axual` when omitted.
    - `instanceName` and `instanceShortName` to point to an instance with:
      - `EnabledAuthenticationMethod` are SSL, SCRAM_SHA_512, OAUTHBEARER
        - SSL using `Axual Dummy Root CA` as the Signing Authority
@@ -291,16 +293,17 @@ go test -p 1 -count 1 ./internal/tests/...
 
 ### Connecting to Different Environments
 
-To run tests against a different Axual Platform instance (e.g., Axual Cloud), set `apiUrl` and
-`authUrl` in [`internal/tests/test_config.yaml`](./internal/tests/test_config.yaml). These two keys
-drive both the Terraform provider block and the direct API check helpers — no need to edit
-`test_provider.go`.
+To run tests against a different Axual Platform instance (e.g., Axual Cloud), set `apiUrl`,
+`authUrl` and `realm` in [`internal/tests/test_config.yaml`](./internal/tests/test_config.yaml).
+These keys drive both the Terraform provider block and the direct API check helpers — no need to
+edit `test_provider.go`. `realm` is optional and defaults to `axual`.
 
 **Example for Axual Cloud:**
 
 ```yaml
 apiUrl: "https://axual.cloud/api"
 authUrl: "https://axual.cloud/auth/realms/<your-realm-name>/protocol/openid-connect/token"
+realm: "<your-realm-name>"
 ```
 
 ## Writing Tests

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -182,6 +182,11 @@ Before running acceptance tests:
 2. **Configure Test Config:**
 
    In [`internal/tests/test_config.yaml`](./internal/tests/test_config.yaml), update:
+   - `apiUrl`: Base URL of the Axual API (e.g. `https://platform.local/api`). Used by both the
+     provider block and the direct API check helpers in `test_provider.go` — single source of truth.
+   - `authUrl`: OAuth2 token endpoint (e.g.
+     `https://platform.local/auth/realms/axual/protocol/openid-connect/token`). Also shared by the
+     provider block and the API check helpers.
    - `instanceName` and `instanceShortName` to point to an instance with:
      - `EnabledAuthenticationMethod` are SSL, SCRAM_SHA_512, OAUTHBEARER
        - SSL using `Axual Dummy Root CA` as the Signing Authority
@@ -286,20 +291,16 @@ go test -p 1 -count 1 ./internal/tests/...
 
 ### Connecting to Different Environments
 
-To run tests against different Axual Platform instances (e.g., Axual Cloud), modify the provider block in [`test_provider.go`](./internal/tests/test_provider.go):
+To run tests against a different Axual Platform instance (e.g., Axual Cloud), set `apiUrl` and
+`authUrl` in [`internal/tests/test_config.yaml`](./internal/tests/test_config.yaml). These two keys
+drive both the Terraform provider block and the direct API check helpers — no need to edit
+`test_provider.go`.
 
 **Example for Axual Cloud:**
 
-```terraform
-provider "axual" {
-  apiurl   = "https://axual.cloud/api"
-  realm    = "<your-realm-name>"
-  username = "<your-username>"
-  password = "<your-password>"
-  clientid = "self-service"
-  authurl  = "https://axual.cloud/auth/realms/<your-realm-name>/protocol/openid-connect/token"
-  scopes   = ["openid", "profile", "email"]
-}
+```yaml
+apiUrl: "https://axual.cloud/api"
+authUrl: "https://axual.cloud/auth/realms/<your-realm-name>/protocol/openid-connect/token"
 ```
 
 ## Writing Tests

--- a/axual-webclient/application_principal.go
+++ b/axual-webclient/application_principal.go
@@ -32,21 +32,6 @@ func (c *Client) CreateApplicationPrincipal(applicationPrincipalRequest [1]Appli
 	return o, nil
 }
 
-func (c *Client) UpdateApplicationPrincipal(id string, applicationUpdatePrincipalRequest ApplicationPrincipalUpdateRequest) (ApplicationPrincipalUpdateResponse, error) {
-	var o ApplicationPrincipalUpdateResponse
-	marshal, err := json.Marshal(applicationUpdatePrincipalRequest)
-	if err != nil {
-		return "Error creating payload for application principal", err
-	}
-	headers := map[string]string{"Content-Type": "application/json"}
-	err = c.RequestAndMap("PATCH", fmt.Sprintf("%s/application_principals/%v", c.ApiURL, id), strings.NewReader(string(marshal)), headers, &o)
-	if err != nil {
-		return "Error sending PATCH request for application principal", err
-	}
-	time.Sleep(2 * time.Second) // Principal application can take significant time to apply in Kafka cluster
-	return o, nil
-}
-
 func (c *Client) ActivateApplicationPrincipal(id string) error {
 	err := c.RequestAndMap("POST", fmt.Sprintf("%s/application_authentications/%v/activate", c.ApiURL, id), nil, nil, nil)
 	if err != nil {

--- a/axual-webclient/instance.go
+++ b/axual-webclient/instance.go
@@ -5,13 +5,18 @@ import (
 	"net/url"
 )
 
-func (c *Client) GetInstanceByNameOrShortName(params url.Values) (*InstanceResponse, error) {
+func (c *Client) GetInstanceByName(name string) (*InstanceResponse, error) {
 	o := InstanceResponse{}
-	endpoint := fmt.Sprintf("findByName?name=%s", url.QueryEscape(params.Get("name")))
-	if params.Get("shortName") != "" {
-		endpoint = fmt.Sprintf("findByShortName?shortName=%s", url.QueryEscape(params.Get("shortName")))
+	err := c.RequestAndMap("GET", fmt.Sprintf("%s/instances/search/findByName?name=%s", c.ApiURL, url.QueryEscape(name)), nil, nil, &o)
+	if err != nil {
+		return nil, err
 	}
-	err := c.RequestAndMap("GET", fmt.Sprintf("%s/instances/search/%s", c.ApiURL, endpoint), nil, nil, &o)
+	return &o, nil
+}
+
+func (c *Client) GetInstanceByShortName(shortName string) (*InstanceResponse, error) {
+	o := InstanceResponse{}
+	err := c.RequestAndMap("GET", fmt.Sprintf("%s/instances/search/findByShortName?shortName=%s", c.ApiURL, url.QueryEscape(shortName)), nil, nil, &o)
 	if err != nil {
 		return nil, err
 	}

--- a/axual-webclient/instance.go
+++ b/axual-webclient/instance.go
@@ -5,10 +5,13 @@ import (
 	"net/url"
 )
 
-func (c *Client) GetInstancesByAttributes(attributes url.Values) (*InstancesResponseByAttributes, error) {
-	o := InstancesResponseByAttributes{}
-
-	err := c.RequestAndMap("GET", fmt.Sprintf("%s/instances/search/findByAttributes?%s", c.ApiURL, attributes.Encode()), nil, nil, &o)
+func (c *Client) GetInstanceByNameOrShortName(params url.Values) (*InstanceResponse, error) {
+	o := InstanceResponse{}
+	endpoint := fmt.Sprintf("findByName?name=%s", url.QueryEscape(params.Get("name")))
+	if params.Get("shortName") != "" {
+		endpoint = fmt.Sprintf("findByShortName?shortName=%s", url.QueryEscape(params.Get("shortName")))
+	}
+	err := c.RequestAndMap("GET", fmt.Sprintf("%s/instances/search/%s", c.ApiURL, endpoint), nil, nil, &o)
 	if err != nil {
 		return nil, err
 	}

--- a/axual-webclient/instance_data.go
+++ b/axual-webclient/instance_data.go
@@ -1,12 +1,8 @@
 package webclient
 
-type InstancesResponseByAttributes struct {
-	Embedded struct {
-		Instances []struct {
-			Name        string `json:"name"`
-			ShortName   string `json:"shortName"`
-			Description string `json:"description"`
-			Uid         string `json:"uid"`
-		} `json:"instances"`
-	} `json:"_embedded"`
+type InstanceResponse struct {
+	Name        string `json:"name"`
+	ShortName   string `json:"shortName"`
+	Description string `json:"description"`
+	Uid         string `json:"uid"`
 }

--- a/internal/provider/data_source_instance.go
+++ b/internal/provider/data_source_instance.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"net/url"
 	"regexp"
 )
 
@@ -101,20 +100,20 @@ func (d *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	params := url.Values{}
 	searchParam := "name"
 	var searchValue string
+	var instanceResponse *webclient.InstanceResponse
+	var err error
 
 	if data.ShortName.ValueString() == "" {
 		searchValue = data.Name.ValueString()
-		params.Set("name", searchValue)
+		instanceResponse, err = d.provider.client.GetInstanceByName(searchValue)
 	} else {
 		searchValue = data.ShortName.ValueString()
-		params.Set("shortName", searchValue)
 		searchParam = "shortName"
+		instanceResponse, err = d.provider.client.GetInstanceByShortName(searchValue)
 	}
 
-	instanceResponse, err := d.provider.client.GetInstanceByNameOrShortName(params)
 	if err != nil {
 		if errors.Is(err, webclient.NotFoundError) {
 			resp.Diagnostics.AddError("Client Error", "Instance not found")

--- a/internal/provider/data_source_instance.go
+++ b/internal/provider/data_source_instance.go
@@ -3,6 +3,7 @@ package provider
 import (
 	webclient "axual-webclient"
 	"context"
+	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -100,51 +101,36 @@ func (d *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 		return
 	}
 
-	attributes := url.Values{}
+	params := url.Values{}
+	searchParam := "name"
+	var searchValue string
 
 	if data.ShortName.ValueString() == "" {
-		attributes.Set("name", data.Name.ValueString())
+		searchValue = data.Name.ValueString()
+		params.Set("name", searchValue)
 	} else {
-		attributes.Set("shortName", data.ShortName.ValueString())
+		searchValue = data.ShortName.ValueString()
+		params.Set("shortName", searchValue)
+		searchParam = "shortName"
 	}
 
-	instanceResponse, err := d.provider.client.GetInstancesByAttributes(attributes)
+	instanceResponse, err := d.provider.client.GetInstanceByNameOrShortName(params)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read instance by name, got error: %s", err))
-		return
-	}
-
-	if len(instanceResponse.Embedded.Instances) == 0 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Instance not found"))
-		return
-	}
-
-	// Find exact match from results, since the API may return partial/substring matches
-	exactMatchIndex := -1
-	for i, inst := range instanceResponse.Embedded.Instances {
-		if data.Name.ValueString() != "" && inst.Name == data.Name.ValueString() {
-			exactMatchIndex = i
-			break
+		if errors.Is(err, webclient.NotFoundError) {
+			resp.Diagnostics.AddError("Client Error", "Instance not found")
+			return
 		}
-		if data.ShortName.ValueString() != "" && inst.ShortName == data.ShortName.ValueString() {
-			exactMatchIndex = i
-			break
-		}
-	}
-	if exactMatchIndex == -1 {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("No instance found with exact name '%s' or short_name '%s'. The API returned %d partial matches.", data.Name.ValueString(), data.ShortName.ValueString(), len(instanceResponse.Embedded.Instances)))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read instance by %s: '%s', got error: %s", searchParam, searchValue, err))
 		return
 	}
 
-	mapInstanceDataSourceResponseToData(ctx, &data, instanceResponse, exactMatchIndex)
+	mapInstanceDataSourceResponseToData(&data, instanceResponse)
 
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 }
 
-func mapInstanceDataSourceResponseToData(ctx context.Context, data *instanceDataSourceData, instanceResponseAttributes *webclient.InstancesResponseByAttributes, index int) {
-
-	instance := instanceResponseAttributes.Embedded.Instances[index]
+func mapInstanceDataSourceResponseToData(data *instanceDataSourceData, instance *webclient.InstanceResponse) {
 
 	data.Id = types.StringValue(instance.Uid)
 	data.Name = types.StringValue(instance.Name)

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_connector_key_trailing_ws.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_connector_key_trailing_ws.tf
@@ -1,0 +1,6 @@
+resource "axual_application_principal" "connector_axual_application_principal" {
+  environment = axual_environment.tf-test-env.id
+  application = axual_application.tf-test-app.id
+  principal   = "${file("{{CERTS}}/generic_application_1.cer")}\n\n"
+  private_key = "${file("{{CERTS}}/generic_application_1.key")}\n\n"
+}

--- a/internal/tests/ApplicationPrincipalResource/axual_application_principal_custom_active.tf
+++ b/internal/tests/ApplicationPrincipalResource/axual_application_principal_custom_active.tf
@@ -1,0 +1,6 @@
+resource "axual_application_principal" "tf-test-app-principal" {
+  environment = axual_environment.tf-test-env.id
+  application = axual_application.tf-test-app.id
+  principal   = file("{{CERTS}}/generic_application_3.cer")
+  active      = true
+}

--- a/internal/tests/test_config.yaml
+++ b/internal/tests/test_config.yaml
@@ -2,6 +2,9 @@ provider:
   # Version is "local" for local provider, the binary path is in .terraformrc under "dev_overrides"
   # Version is a specific version like "2.4.1" for a public official registry version
   version: "local"
+apiUrl: "YOUR_API_URL"
+authUrl: "YOUR_AUTH_URL"
+realm: "YOUR_REALM"
 instanceName: "YOUR_INSTANCE_NAME"
 instanceShortName: "YOUR_INSTANCE_SHORT_NAME"
 groupName: "YOUR_GROUP_NAME"

--- a/internal/tests/test_provider.go
+++ b/internal/tests/test_provider.go
@@ -20,13 +20,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Struct to hold provider configuration from YAML file
+// ProviderConfig Struct to hold provider configuration from the YAML file
 type ProviderConfig struct {
 	Provider struct {
 		Version string `yaml:"version"` // Can be "local" or a version from the registry (e.g., "2.4.1")
 	} `yaml:"provider"`
 	ApiUrl            string `yaml:"apiUrl"`
 	AuthUrl           string `yaml:"authUrl"`
+	Realm             string `yaml:"realm"`
 	InstanceName      string `yaml:"instanceName"`
 	InstanceShortName string `yaml:"instanceShortName"`
 	GroupName         string `yaml:"groupName"`
@@ -35,7 +36,7 @@ type ProviderConfig struct {
 	Password          string `yaml:"password"`
 }
 
-// Function to load the configuration from a YAML file
+// LoadProviderConfig Function to load the configuration from a YAML file
 func LoadProviderConfig() (ProviderConfig, error) {
 	file, err := os.ReadFile("../test_config.yaml")
 	if err != nil {
@@ -46,6 +47,9 @@ func LoadProviderConfig() (ProviderConfig, error) {
 	err = yaml.Unmarshal(file, &config)
 	if err != nil {
 		return ProviderConfig{}, err
+	}
+	if config.Realm == "" {
+		config.Realm = "axual"
 	}
 	return config, nil
 }
@@ -72,19 +76,19 @@ func testProviderConfig() (resource.TestCase, error) {
 			ProtoV6ProviderFactories: testAccProviderFactories(),
 			ExternalProviders:        timeProvider,
 		}, nil
-	} else {
-		// Use a specific version from the registry
-		external := map[string]resource.ExternalProvider{
-			"axual": {
-				VersionConstraint: config.Provider.Version,
-				Source:            "Axual/axual",
-			},
-			"time": {Source: "hashicorp/time"},
-		}
-		return resource.TestCase{
-			ExternalProviders: external,
-		}, nil
 	}
+	// Use a specific version from the registry
+	external := map[string]resource.ExternalProvider{
+		"axual": {
+			VersionConstraint: config.Provider.Version,
+			Source:            "Axual/axual",
+		},
+		"time": {Source: "hashicorp/time"},
+	}
+	return resource.TestCase{
+		ExternalProviders: external,
+	}, nil
+
 }
 
 func GetProviderConfig(t *testing.T) resource.TestCase {
@@ -102,7 +106,7 @@ func testAccProviderFactories() map[string]func() (tfprotov6.ProviderServer, err
 	}
 }
 
-// Reusable provider configuration for resource creation
+// GetProvider Reusable provider configuration for resource creation
 func GetProvider() string {
 	// Load the provider configuration from the YAML file
 	config, err := LoadProviderConfig()
@@ -110,16 +114,15 @@ func GetProvider() string {
 		panic("Error loading provider config: " + err.Error())
 	}
 
-	// Local Platform.local setup
 	providerBlock := `
-	provider "axual" {
+		provider "axual" {
 		authmode = "keycloak"
-		apiurl   = "https://platform.local/api"
-		realm    = "local"
+		apiurl   = "` + config.ApiUrl + `"
+		realm    = "` + config.Realm + `"
 		username = "` + config.Username + `"
 		password = "` + config.Password + `"
 		clientid = "self-service"
-		authurl  = "https://platform.local/auth/realms/local/protocol/openid-connect/token"
+		authurl  = "` + config.AuthUrl + `"
 		scopes   = ["openid", "profile", "email"]
 	}
 	`
@@ -202,7 +205,7 @@ func apiClient() (*webclient.Client, error) {
 	}
 	return webclient.NewClient(
 		config.ApiUrl,
-		"axual",
+		config.Realm,
 		webclient.AuthStruct{
 			Username: config.Username,
 			Password: config.Password,
@@ -249,7 +252,7 @@ func CheckPrincipalActiveInAPI(resourceName string, wantActive bool) resource.Te
 	}
 }
 
-// Helper function to read the file and compare its content
+// CheckBodyMatchesFile Helper function to read the file and compare its content
 func CheckBodyMatchesFile(resourceName, attrName, filePath string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Read the file

--- a/internal/tests/test_provider.go
+++ b/internal/tests/test_provider.go
@@ -8,6 +8,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	webclient "axual-webclient"
 
 	"axual.com/terraform-provider-axual/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -22,6 +25,8 @@ type ProviderConfig struct {
 	Provider struct {
 		Version string `yaml:"version"` // Can be "local" or a version from the registry (e.g., "2.4.1")
 	} `yaml:"provider"`
+	ApiUrl            string `yaml:"apiUrl"`
+	AuthUrl           string `yaml:"authUrl"`
 	InstanceName      string `yaml:"instanceName"`
 	InstanceShortName string `yaml:"instanceShortName"`
 	GroupName         string `yaml:"groupName"`
@@ -178,12 +183,70 @@ func CertsDir() string {
 	if !ok {
 		log.Panic("unable to determine CertsDir via runtime.Caller")
 	}
-	return filepath.Join(filepath.Dir(file), "shared_certs")
+	return filepath.Join(filepath.Dir(file), "sharedCerts")
 }
 
 // CertPath returns the absolute path to a named cert in the shared certs directory.
 func CertPath(name string) string {
 	return filepath.Join(CertsDir(), name)
+}
+
+// apiClient builds an authenticated webclient against the configured platform, mirroring the
+// provider block used by GetProvider (apiUrl/authUrl come from test_config.yaml). Used by check
+// helpers that must inspect live API state that the provider deliberately does not refresh into
+// Terraform state (e.g. a principal's activation status).
+func apiClient() (*webclient.Client, error) {
+	config, err := LoadProviderConfig()
+	if err != nil {
+		return nil, err
+	}
+	return webclient.NewClient(
+		config.ApiUrl,
+		"axual",
+		webclient.AuthStruct{
+			Username: config.Username,
+			Password: config.Password,
+			Url:      config.AuthUrl,
+			ClientId: "self-service",
+			Scopes:   []string{"openid", "profile", "email"},
+			AuthMode: "keycloak",
+		},
+	)
+}
+
+// CheckPrincipalActiveInAPI asserts the LIVE API activation status of the principal backing the
+// given resource (looked up by its state `id`). The provider treats `active` as write-only intent
+// and never refreshes it from the API, so state-based checks cannot observe activation inherited
+// across a rotation — this reads the API directly. Retries briefly to absorb activation
+// propagation lag.
+func CheckPrincipalActiveInAPI(resourceName string, wantActive bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("no resource %q in state", resourceName)
+		}
+		id := rs.Primary.Attributes["id"]
+		if id == "" {
+			return fmt.Errorf("resource %q has empty id in state", resourceName)
+		}
+		client, err := apiClient()
+		if err != nil {
+			return fmt.Errorf("unable to build API client: %w", err)
+		}
+		var lastActive bool
+		for attempt := 0; attempt < 5; attempt++ {
+			p, err := client.ReadApplicationPrincipal(id)
+			if err != nil {
+				return fmt.Errorf("unable to read principal %s from API: %w", id, err)
+			}
+			lastActive = p.Active != nil && *p.Active
+			if lastActive == wantActive {
+				return nil
+			}
+			time.Sleep(2 * time.Second)
+		}
+		return fmt.Errorf("principal %q (%s): expected API active=%t, got %t", resourceName, id, wantActive, lastActive)
+	}
 }
 
 // Helper function to read the file and compare its content


### PR DESCRIPTION
## What

Switches the `axual_instance` data source from `/instances/search/findByAttributes` (substring matching) to `/instances/search/findByName` and `/instances/search/findByShortName`, which use FULL_MATCH and return a single instance. Mirrors the existing Application data source.

This removes the client-side partial-match loop that was needed to filter out substring hits, and handles a 404 as a clean "Instance not found" error.

## Why

`findByAttributes` does substring matching, so looking up an instance by name or short name could return partial matches and risked selecting the wrong one. The `findBy*` endpoints match exactly.

## Changes

**Instance data source (primary)**
- webclient: `GetInstancesByAttributes` → `GetInstanceByNameOrShortName`
- webclient: embedded-list `InstancesResponseByAttributes` → single-object `InstanceResponse`
- data source: map single object, drop partial-match loop, map 404 → "Instance not found"
- CHANGELOG updated

**Also included in this branch**
- Expand provider/test config with `apiUrl`, `authUrl`, `realm` support; refactor test setup (`test_provider.go`, `test_config.yaml`)
- Add missing test TF for connector certificate rotation
- Add direct API state-check helpers; refactor shared certs logic in tests
- Remove unused `UpdateApplicationPrincipal` method