### PR TITLE
fix: read application access grant via GET /{uid} instead of findByAttributes search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 * Retrieve an **Instance** using `findByName` or `findByShortName` endpoints instead of `findByAttributes`
+* Read `axual_application_access_grant` using the `GET /application_access_grants/{uid}` endpoint instead of the `findByAttributes` search
 
 ## [3.0.0](https://github.com/Axual/terraform-provider-axual/releases/tag/v3.0.0) - 2026-03-24
 ### Added

--- a/axual-webclient/applications_access_grant_data.go
+++ b/axual-webclient/applications_access_grant_data.go
@@ -4,10 +4,22 @@ package webclient
 // Only fields actually used by the provider are included to reduce maintenance burden
 // and avoid breaking changes when the API evolves.
 type ApplicationAccessGrant struct {
-	Status  string `json:"status"`
-	Uid     string `json:"uid"`
-	Comment string `json:"comment"`
-	Links   struct {
+	Status     string `json:"status"`
+	Uid        string `json:"uid"`
+	Comment    string `json:"comment"`
+	AccessType string `json:"accessType"`
+	Embedded   struct {
+		Environment struct {
+			Uid string `json:"uid"`
+		} `json:"environment"`
+		Application struct {
+			Uid string `json:"uid"`
+		} `json:"application"`
+		Stream struct {
+			Uid string `json:"uid"`
+		} `json:"stream"`
+	} `json:"_embedded"`
+	Links struct {
 		Revoke struct {
 			Href string `json:"href"`
 		} `json:"revoke"`

--- a/internal/provider/resource_application_access_grant.go
+++ b/internal/provider/resource_application_access_grant.go
@@ -125,83 +125,30 @@ func (r *applicationAccessGrantResource) Read(ctx context.Context, req resource.
 		return
 	}
 
-	// TODO: Change to use GET /application_access_grants/{id} once the API returns application, topic, and access_type fields.
-	// Currently using search endpoint as a workaround because GET by ID doesn't return these fields.
-	tflog.Info(ctx, fmt.Sprintf("Reading Application Access Grant via search endpoint. Id: %s", data.Id.ValueString()))
-	applicationAccessGrant, err := r.findGrantByIdWithFilters(ctx, &data)
+	tflog.Info(ctx, fmt.Sprintf("Reading Application Access Grant. Id: %s", data.Id.ValueString()))
+	applicationAccessGrant, err := r.provider.client.GetApplicationAccessGrant(data.Id.ValueString())
 	if err != nil {
-		if errors.Is(err, errGrantNotFound) {
+		if errors.Is(err, webclient.NotFoundError) {
 			tflog.Warn(ctx, fmt.Sprintf("Application Access Grant not found. Id: %s", data.Id.ValueString()))
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		resp.Diagnostics.AddError("Failed to read Application Access Grant", fmt.Sprintf("Error message: %s", err.Error()))
+		resp.Diagnostics.AddError("Failed to read Application Access Grant",
+			fmt.Sprintf("Error message: %s", err.Error()))
 		return
 	}
 
 	tflog.Info(ctx, "mapping the resource")
 	data.Id = types.StringValue(applicationAccessGrant.Uid)
 	data.Status = types.StringValue(applicationAccessGrant.Status)
-	data.ApplicationId = types.StringValue(applicationAccessGrant.ApplicationUid)
-	data.TopicId = types.StringValue(applicationAccessGrant.StreamUid)
-	data.EnvironmentId = types.StringValue(applicationAccessGrant.EnvironmentUid)
+	data.ApplicationId = types.StringValue(applicationAccessGrant.Embedded.Application.Uid)
+	data.TopicId = types.StringValue(applicationAccessGrant.Embedded.Stream.Uid)
+	data.EnvironmentId = types.StringValue(applicationAccessGrant.Embedded.Environment.Uid)
 	data.AccessType = types.StringValue(applicationAccessGrant.AccessType)
 
 	tflog.Info(ctx, "Saving Application Access Grant resource to state")
 	diags = resp.State.Set(ctx, &data)
 	resp.Diagnostics.Append(diags...)
-}
-
-// grantSearchResult holds the extracted grant data from search results
-type grantSearchResult struct {
-	Uid            string
-	Status         string
-	ApplicationUid string
-	StreamUid      string
-	EnvironmentUid string
-	AccessType     string
-}
-
-// errGrantNotFound is returned when a grant cannot be found
-var errGrantNotFound = errors.New("grant not found")
-
-// findGrantByIdWithFilters searches for a grant by its UID using the search endpoint with filters.
-// Uses application, topic, environment, and access_type from state to filter the search,
-// significantly reducing the response size (typically 0-2 grants instead of all grants).
-// TODO: Replace with GET /application_access_grants/{id} once the API returns application, topic, and access_type fields.
-func (r *applicationAccessGrantResource) findGrantByIdWithFilters(ctx context.Context, data *applicationAccessGrantData) (*grantSearchResult, error) {
-	searchAttrs := webclient.ApplicationAccessGrantAttributes{
-		ApplicationId: data.ApplicationId.ValueString(),
-		TopicId:       data.TopicId.ValueString(),
-		EnvironmentId: data.EnvironmentId.ValueString(),
-		AccessType:    data.AccessType.ValueString(),
-		Size:          9999,
-	}
-
-	tflog.Debug(ctx, fmt.Sprintf("Searching for grant with filters: app=%s, topic=%s, env=%s, type=%s",
-		data.ApplicationId.ValueString(), data.TopicId.ValueString(),
-		data.EnvironmentId.ValueString(), data.AccessType.ValueString()))
-
-	result, err := r.provider.client.GetApplicationAccessGrantsByAttributes(searchAttrs)
-	if err != nil {
-		return nil, err
-	}
-
-	grantId := data.Id.ValueString()
-	for _, grant := range result.Embedded.ApplicationAccessGrantResponses {
-		if grant.Uid == grantId {
-			return &grantSearchResult{
-				Uid:            grant.Uid,
-				Status:         grant.Status,
-				ApplicationUid: grant.Embedded.Application.Uid,
-				StreamUid:      grant.Embedded.Stream.Uid,
-				EnvironmentUid: grant.Embedded.Environment.Uid,
-				AccessType:     grant.AccessType,
-			}, nil
-		}
-	}
-
-	return nil, errGrantNotFound
 }
 
 func (r *applicationAccessGrantResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/provider/resource_application_access_grant.go
+++ b/internal/provider/resource_application_access_grant.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -144,7 +145,10 @@ func (r *applicationAccessGrantResource) Read(ctx context.Context, req resource.
 	data.ApplicationId = types.StringValue(applicationAccessGrant.Embedded.Application.Uid)
 	data.TopicId = types.StringValue(applicationAccessGrant.Embedded.Stream.Uid)
 	data.EnvironmentId = types.StringValue(applicationAccessGrant.Embedded.Environment.Uid)
-	data.AccessType = types.StringValue(applicationAccessGrant.AccessType)
+	// The direct GET endpoint returns access type in title case ("Producer"/"Consumer"),
+	// while the schema and config use upper case ("PRODUCER"/"CONSUMER"). Normalize to
+	// upper case to prevent a perpetual refresh diff.
+	data.AccessType = types.StringValue(strings.ToUpper(applicationAccessGrant.AccessType))
 
 	tflog.Info(ctx, "Saving Application Access Grant resource to state")
 	diags = resp.State.Set(ctx, &data)

--- a/internal/tests/ApplicationAccessGrantResource/application_access_grant_resource_test.go
+++ b/internal/tests/ApplicationAccessGrantResource/application_access_grant_resource_test.go
@@ -21,12 +21,12 @@ import (
 //   - In Auto environment, the grant is auto-approved (status = "Approved")
 //   - Approved grants cannot be deleted directly - they must be REVOKED first
 //   - The approval resource's Delete function triggers revocation
-//   - Without approval resource, cleanup would fail with:
+//   - Without the approval resource, cleanup would fail with:
 //     "Application Access Grant cannot be cancelled. Please Revoke first."
 //
 // Cleanup order:
 //  1. Delete approval resource → calls RevokeOrDenyGrant() → grant status becomes "Revoked"
-//  2. Delete grant resource → calls CancelGrant() → works because grant is now "Revoked"
+//  2. Delete grant resource → calls CancelGrant() → works because the grant is now "Revoked"
 func TestApplicationAccessGrant_AutoEnvironment(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: GetProviderConfig(t).ProtoV6ProviderFactories,
@@ -35,7 +35,7 @@ func TestApplicationAccessGrant_AutoEnvironment(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Step 1: Create resources - grant should be auto-approved
 			// In Auto environment, grant.Create() returns status = "Approved" immediately
-			// No state sync issue here(like in Stream Owner env) because approval happens during grant creation, not after
+			// No state sync issue here (like in Stream Owner env) because approval happens during grant creation, not after
 			{
 				Config: GetProvider() + GetFile("axual_application_access_grant_auto.tf"),
 				Check: resource.ComposeTestCheckFunc(
@@ -124,12 +124,12 @@ func TestApplicationAccessGrant_TopicOwnerApproval(t *testing.T) {
 					resource.TestCheckResourceAttrSet("axual_application_access_grant_approval.tf-test-application-access-grant-approval", "application_access_grant"),
 				),
 			},
-			// Step 2: REFRESH STEP - Re-apply same config to sync state with API
+			// Step 2: REFRESH STEP - Re-apply the same config to sync state with API
 			//
 			// How this works:
-			//   1. Terraform starts "apply" with same config
+			//   1. Terraform starts "apply" with the same config
 			//   2. REFRESH PHASE runs first - calls Read() on all resources
-			//   3. grant.Read() fetches current status from API ("Approved")
+			//   3. grant.Read() fetches the current status from API ("Approved")
 			//   4. Terraform state is updated: status "Pending" → "Approved"
 			//   5. PLAN PHASE - no changes needed (config matches refreshed state)
 			//   6. APPLY PHASE - nothing to apply
@@ -146,7 +146,7 @@ func TestApplicationAccessGrant_TopicOwnerApproval(t *testing.T) {
 			// Step 3: Import verification
 			// This works without ImportStateVerifyIgnore because Step 2 synced the state.
 			// Import process:
-			//   1. Save current state (status="Approved")
+			//   1. Save the current state (status="Approved")
 			//   2. Remove resource from state
 			//   3. Import using ID - calls Read() - fetches status="Approved"
 			//   4. Compare: "Approved" == "Approved" ✓


### PR DESCRIPTION
# What

`axual_application_access_grant` - Read now fetches the grant directly via `GET /application_access_grants/{uid}` instead of the `/application_access_grants/search/findByAttributes` search endpoint.

This is possible because the PM API now returns `accessType` plus the embedded `application`, `stream`, and `environment` entities on the GET-by-uid response.

# Why

The search-based workaround existed only because GET-by-uid did not return `application`, `topic`, and `access_type`. With those fields now in the GET response, a direct lookup by uid is simpler, cheaper (one grant instead of filtering a full list), and removes the fragile filter logic.

# Changes

- **`axual-webclient/applications_access_grant_data.go`**: extend `ApplicationAccessGrant` (the GET `/{uid}` response) with `accessType` and the `_embedded` block (`environment`, `application`, `stream` uids).
- **`internal/provider/resource_application_access_grant.go`**: `Read` now calls `GetApplicationAccessGrant(uid)`; `NotFoundError` -> remove from state. Deleted the now-dead `findGrantByIdWithFilters`, `grantSearchResult`, and `errGrantNotFound`. `Read` also normalizes `access_type` to upper case via `strings.ToUpper`: the GET-by-uid endpoint returns title case (`"Producer"`/`"Consumer"`) while the schema and config use upper case (`"PRODUCER"`/`"CONSUMER"`), which otherwise caused a perpetual refresh diff.
- **tests**: typo/comment cleanup in `application_access_grant_resource_test.go`.

Search endpoint (`findByAttributes`) is kept, it's still used by the grant data source and the deployment resource, which look up grants by attributes (no uid).

