### PR TITLE
chore: fix Axual Connect documentation URLs and update AVRO schema test namespace

### DIFF
--- a/docs/guides/connector-application.md
+++ b/docs/guides/connector-application.md
@@ -27,7 +27,7 @@ To create and start a connector application, we need these Axual Terraform resou
        - Updating `axual_application_deployment` stops the connector if it was running, updates the config, and starts it.
        - Deleting `axual_application_deployment` stops the connector if it was running, then deletes it.
 
-To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connectindex-developer.html
+To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connect/index-developer.html
 
 ### Example Resources:
 - When trying out this example, make sure to:

--- a/docs/guides/connector-application.md
+++ b/docs/guides/connector-application.md
@@ -10,7 +10,7 @@ To create and start a connector application, we need these Axual Terraform resou
   3. `axual_application` 
       - These are connector application specific properties: 
       - `application_type = "Connector"`
-        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html.
+        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html.
           - For example: `application_class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"`.
         - `type="SINK"` or `type="SOURCE"`
   4. `axual_application_principal` 
@@ -27,7 +27,7 @@ To create and start a connector application, we need these Axual Terraform resou
        - Updating `axual_application_deployment` stops the connector if it was running, updates the config, and starts it.
        - Deleting `axual_application_deployment` stops the connector if it was running, then deletes it.
 
-To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/developer/index-developer.html
+To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connectindex-developer.html
 
 ### Example Resources:
 - When trying out this example, make sure to:

--- a/docs/guides/connector-application.md
+++ b/docs/guides/connector-application.md
@@ -10,7 +10,7 @@ To create and start a connector application, we need these Axual Terraform resou
   3. `axual_application` 
       - These are connector application specific properties: 
       - `application_type = "Connector"`
-        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html.
+        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html.
           - For example: `application_class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"`.
         - `type="SINK"` or `type="SOURCE"`
   4. `axual_application_principal` 

--- a/docs/guides/connector-application.md
+++ b/docs/guides/connector-application.md
@@ -10,7 +10,7 @@ To create and start a connector application, we need these Axual Terraform resou
   3. `axual_application` 
       - These are connector application specific properties: 
       - `application_type = "Connector"`
-        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html.
+        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html.
           - For example: `application_class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"`.
         - `type="SINK"` or `type="SOURCE"`
   4. `axual_application_principal` 
@@ -27,7 +27,7 @@ To create and start a connector application, we need these Axual Terraform resou
        - Updating `axual_application_deployment` stops the connector if it was running, updates the config, and starts it.
        - Deleting `axual_application_deployment` stops the connector if it was running, then deletes it.
 
-To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connect/developer/index-developer.html
+To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/developer/index-developer.html
 
 ### Example Resources:
 - When trying out this example, make sure to:

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -22,7 +22,7 @@ Axual Terraform Provider supports both Custom and Connector Application Types. R
 
 ### Optional
 
-- `application_class` (String) The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html
+- `application_class` (String) The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html
 - `description` (String) Application Description. A short summary describing the application
 - `type` (String) If application_type is Custom, type can be: Java, Kafka Streams, Pega, SAP, DotNet, Bridge, Python, KSML, Other. If application_type is Connector, type can be: SINK, SOURCE. If application_type is Ksml, this field must be null/omitted. Use 'Other' when the desired application type is not available in the predefined list.
 - `viewers` (Set of String) Application Viewer Groups define which Groups are authorized to View Application Configuration, regardless of ownership and visibility. Read more: https://docs.axual.io/axual/2026.1/self-service/user-group-management.html#viewer-groups

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -22,7 +22,7 @@ Axual Terraform Provider supports both Custom and Connector Application Types. R
 
 ### Optional
 
-- `application_class` (String) The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html
+- `application_class` (String) The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html
 - `description` (String) Application Description. A short summary describing the application
 - `type` (String) If application_type is Custom, type can be: Java, Kafka Streams, Pega, SAP, DotNet, Bridge, Python, KSML, Other. If application_type is Connector, type can be: SINK, SOURCE. If application_type is Ksml, this field must be null/omitted. Use 'Other' when the desired application type is not available in the predefined list.
 - `viewers` (Set of String) Application Viewer Groups define which Groups are authorized to View Application Configuration, regardless of ownership and visibility. Read more: https://docs.axual.io/axual/2026.1/self-service/user-group-management.html#viewer-groups

--- a/docs/resources/application.md
+++ b/docs/resources/application.md
@@ -22,7 +22,7 @@ Axual Terraform Provider supports both Custom and Connector Application Types. R
 
 ### Optional
 
-- `application_class` (String) The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html
+- `application_class` (String) The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html
 - `description` (String) Application Description. A short summary describing the application
 - `type` (String) If application_type is Custom, type can be: Java, Kafka Streams, Pega, SAP, DotNet, Bridge, Python, KSML, Other. If application_type is Connector, type can be: SINK, SOURCE. If application_type is Ksml, this field must be null/omitted. Use 'Other' when the desired application type is not available in the predefined list.
 - `viewers` (Set of String) Application Viewer Groups define which Groups are authorized to View Application Configuration, regardless of ownership and visibility. Read more: https://docs.axual.io/axual/2026.1/self-service/user-group-management.html#viewer-groups

--- a/docs/resources/application_deployment.md
+++ b/docs/resources/application_deployment.md
@@ -8,7 +8,7 @@ An Application Deployment stores the configs for 'Connector' or 'Ksml' applicati
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
-- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connectstarting-connectors.html).
+- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connect/starting-connectors.html).
 - Currently, a data source for `axual_application_deployment` is not supported.
 
 ### Prerequisite: active Application Principal (Connector only)

--- a/docs/resources/application_deployment.md
+++ b/docs/resources/application_deployment.md
@@ -4,11 +4,11 @@ An Application Deployment stores the configs for 'Connector' or 'Ksml' applicati
 
 
 ## Usage
-- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html).
+- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html).
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
-- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connect/developer/starting-connectors.html).
+- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/developer/starting-connectors.html).
 - Currently, a data source for `axual_application_deployment` is not supported.
 
 ### Prerequisite: active Application Principal (Connector only)
@@ -51,7 +51,7 @@ KSML deployments are unaffected — they allow one authentication (`axual_applic
 
 ### Optional
 
-- `configs` (Map of String, Sensitive) Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html
+- `configs` (Map of String, Sensitive) Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html
 - `definition` (String, Sensitive) KSML definition for Application Deployment. Required for KSML deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands.
 - `deployment_size` (String) The deployment size for KSML applications. Optional for KSML deployments. If not specified, the Platform Manager will assign a default value.
 - `restart_policy` (String) The restart policy for KSML applications. Valid values are 'on_exit' and 'never'. Required for KSML deployments.

--- a/docs/resources/application_deployment.md
+++ b/docs/resources/application_deployment.md
@@ -4,7 +4,7 @@ An Application Deployment stores the configs for 'Connector' or 'Ksml' applicati
 
 
 ## Usage
-- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html).
+- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html).
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
@@ -51,7 +51,7 @@ KSML deployments are unaffected — they allow one authentication (`axual_applic
 
 ### Optional
 
-- `configs` (Map of String, Sensitive) Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html
+- `configs` (Map of String, Sensitive) Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html
 - `definition` (String, Sensitive) KSML definition for Application Deployment. Required for KSML deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands.
 - `deployment_size` (String) The deployment size for KSML applications. Optional for KSML deployments. If not specified, the Platform Manager will assign a default value.
 - `restart_policy` (String) The restart policy for KSML applications. Valid values are 'on_exit' and 'never'. Required for KSML deployments.

--- a/docs/resources/application_deployment.md
+++ b/docs/resources/application_deployment.md
@@ -4,11 +4,11 @@ An Application Deployment stores the configs for 'Connector' or 'Ksml' applicati
 
 
 ## Usage
-- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html).
+- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html).
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
-- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/developer/starting-connectors.html).
+- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connectstarting-connectors.html).
 - Currently, a data source for `axual_application_deployment` is not supported.
 
 ### Prerequisite: active Application Principal (Connector only)
@@ -51,7 +51,7 @@ KSML deployments are unaffected — they allow one authentication (`axual_applic
 
 ### Optional
 
-- `configs` (Map of String, Sensitive) Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html
+- `configs` (Map of String, Sensitive) Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html
 - `definition` (String, Sensitive) KSML definition for Application Deployment. Required for KSML deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands.
 - `deployment_size` (String) The deployment size for KSML applications. Optional for KSML deployments. If not specified, the Platform Manager will assign a default value.
 - `restart_policy` (String) The restart policy for KSML applications. Valid values are 'on_exit' and 'never'. Required for KSML deployments.

--- a/internal/provider/data_source_application.go
+++ b/internal/provider/data_source_application.go
@@ -91,7 +91,7 @@ func (d *applicationDataSource) Schema(ctx context.Context, req datasource.Schem
 			},
 			"application_class": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html",
 			},
 			"visibility": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/data_source_application.go
+++ b/internal/provider/data_source_application.go
@@ -91,7 +91,7 @@ func (d *applicationDataSource) Schema(ctx context.Context, req datasource.Schem
 			},
 			"application_class": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html",
 			},
 			"visibility": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/data_source_application.go
+++ b/internal/provider/data_source_application.go
@@ -4,6 +4,9 @@ import (
 	webclient "axual-webclient"
 	"context"
 	"fmt"
+	"net/url"
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/datasourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -11,8 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"net/url"
-	"regexp"
 )
 
 var _ datasource.DataSource = &applicationDataSource{}
@@ -90,7 +91,7 @@ func (d *applicationDataSource) Schema(ctx context.Context, req datasource.Schem
 			},
 			"application_class": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
 			},
 			"visibility": schema.StringAttribute{
 				Computed:            true,

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -2,10 +2,12 @@ package provider
 
 import (
 	webclient "axual-webclient"
-	custom_validator "axual.com/terraform-provider-axual/internal/custom-validator"
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
+
+	custom_validator "axual.com/terraform-provider-axual/internal/custom-validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -16,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"regexp"
 )
 
 var _ resource.Resource = &applicationResource{}
@@ -103,7 +104,7 @@ func (r *applicationResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"application_class": schema.StringAttribute{
-				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
 				Optional:            true,
 			},
 			"visibility": schema.StringAttribute{

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -104,7 +104,7 @@ func (r *applicationResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"application_class": schema.StringAttribute{
-				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html",
 				Optional:            true,
 			},
 			"visibility": schema.StringAttribute{

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -104,7 +104,7 @@ func (r *applicationResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"application_class": schema.StringAttribute{
-				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "The application's plugin class. Required if application_type is Connector. For example com.couchbase.connect.kafka.CouchbaseSinkConnector. All available application plugin class names, pluginTypes and pluginConfigs listed here- GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html",
 				Optional:            true,
 			},
 			"visibility": schema.StringAttribute{

--- a/internal/provider/resource_application_deployment.go
+++ b/internal/provider/resource_application_deployment.go
@@ -78,7 +78,7 @@ func (r *applicationDeploymentResource) Schema(ctx context.Context, req resource
 				},
 			},
 			"configs": schema.MapAttribute{
-				MarkdownDescription: "Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
 				Optional:            true,
 				ElementType:         types.StringType,
 				Sensitive:           true,

--- a/internal/provider/resource_application_deployment.go
+++ b/internal/provider/resource_application_deployment.go
@@ -78,7 +78,7 @@ func (r *applicationDeploymentResource) Schema(ctx context.Context, req resource
 				},
 			},
 			"configs": schema.MapAttribute{
-				MarkdownDescription: "Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html",
 				Optional:            true,
 				ElementType:         types.StringType,
 				Sensitive:           true,

--- a/internal/provider/resource_application_deployment.go
+++ b/internal/provider/resource_application_deployment.go
@@ -78,7 +78,7 @@ func (r *applicationDeploymentResource) Schema(ctx context.Context, req resource
 				},
 			},
 			"configs": schema.MapAttribute{
-				MarkdownDescription: "Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html",
+				MarkdownDescription: "Connector config for Application Deployment. Required for Connector deployments. This field is Sensitive and will not be displayed in server log outputs when using Terraform commands. All available application plugin class names, plugin types and plugin configs are listed here in API- `GET: /api/connect_plugins?page=0&size=9999&sort=pluginClass` and in Axual Connect Docs: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html",
 				Optional:            true,
 				ElementType:         types.StringType,
 				Sensitive:           true,

--- a/internal/tests/SchemaVersionResource/avro-schemas/gitops_test_2_v1.avsc
+++ b/internal/tests/SchemaVersionResource/avro-schemas/gitops_test_2_v1.avsc
@@ -1,7 +1,7 @@
 {
   "type" : "record",
   "name" : "GitOpsTest2",
-  "namespace" : "io.axual.general",
+  "namespace" : "io.axual.qa.general",
   "doc" : "Object type that is supposed to be filled with a gitops test value. This should be used when the Key is irrelevant.",
   "fields" : [ {
     "name" : "gitops2",

--- a/internal/tests/SchemaVersionResource/schema_version_resource_avro_test.go
+++ b/internal/tests/SchemaVersionResource/schema_version_resource_avro_test.go
@@ -100,7 +100,7 @@ func TestSchemaVersionAvroWithOwnersResource(t *testing.T) {
 
 					resource.TestCheckResourceAttr("axual_schema_version.test_v2_with_owner", "description", "Gitops test schema version"),
 					resource.TestCheckResourceAttr("axual_schema_version.test_v2_with_owner", "version", "1.0.0"),
-					resource.TestCheckResourceAttr("axual_schema_version.test_v2_with_owner", "full_name", "io.axual.general.GitOpsTest2"),
+					resource.TestCheckResourceAttr("axual_schema_version.test_v2_with_owner", "full_name", "io.axual.qa.general.GitOpsTest2"),
 					resource.TestCheckResourceAttrSet("axual_schema_version.test_v2_with_owner", "schema_id"),
 					resource.TestCheckResourceAttrSet("axual_schema_version.test_v2_with_owner", "id"),
 					resource.TestCheckResourceAttrSet("axual_schema_version.test_v2_with_owner", "owners"),
@@ -131,7 +131,7 @@ func TestSchemaVersionAvroWithExplicitTypeResource(t *testing.T) {
 				Config: GetProvider() + GetFile("axual_schema_version_avro_with_type.tf"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("axual_schema_version.test_avro_explicit_type_v1", "version", "1.0.0"),
-					resource.TestCheckResourceAttr("axual_schema_version.test_avro_explicit_type_v1", "full_name", "io.axual.general.GitOpsTest2"),
+					resource.TestCheckResourceAttr("axual_schema_version.test_avro_explicit_type_v1", "full_name", "io.axual.qa.general.GitOpsTest2"),
 					resource.TestCheckResourceAttr("axual_schema_version.test_avro_explicit_type_v1", "description", "Gitops test schema version with explicit AVRO type"),
 					resource.TestCheckResourceAttr("axual_schema_version.test_avro_explicit_type_v1", "type", "AVRO"),
 					CheckBodyMatchesFile("axual_schema_version.test_avro_explicit_type_v1", "body", "avro-schemas/gitops_test_2_v1.avsc"),

--- a/templates/guides/connector-application.md
+++ b/templates/guides/connector-application.md
@@ -27,7 +27,7 @@ To create and start a connector application, we need these Axual Terraform resou
        - Updating `axual_application_deployment` stops the connector if it was running, updates the config, and starts it.
        - Deleting `axual_application_deployment` stops the connector if it was running, then deletes it.
 
-To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connectindex-developer.html
+To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connect/index-developer.html
 
 ### Example Resources:
 - When trying out this example, make sure to:

--- a/templates/guides/connector-application.md
+++ b/templates/guides/connector-application.md
@@ -10,7 +10,7 @@ To create and start a connector application, we need these Axual Terraform resou
   3. `axual_application` 
       - These are connector application specific properties: 
       - `application_type = "Connector"`
-        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html.
+        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html.
           - For example: `application_class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"`.
         - `type="SINK"` or `type="SOURCE"`
   4. `axual_application_principal` 
@@ -27,7 +27,7 @@ To create and start a connector application, we need these Axual Terraform resou
        - Updating `axual_application_deployment` stops the connector if it was running, updates the config, and starts it.
        - Deleting `axual_application_deployment` stops the connector if it was running, then deletes it.
 
-To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/developer/index-developer.html
+To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connectindex-developer.html
 
 ### Example Resources:
 - When trying out this example, make sure to:

--- a/templates/guides/connector-application.md
+++ b/templates/guides/connector-application.md
@@ -10,7 +10,7 @@ To create and start a connector application, we need these Axual Terraform resou
   3. `axual_application` 
       - These are connector application specific properties: 
       - `application_type = "Connector"`
-        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html.
+        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html.
           - For example: `application_class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"`.
         - `type="SINK"` or `type="SOURCE"`
   4. `axual_application_principal` 

--- a/templates/guides/connector-application.md
+++ b/templates/guides/connector-application.md
@@ -10,7 +10,7 @@ To create and start a connector application, we need these Axual Terraform resou
   3. `axual_application` 
       - These are connector application specific properties: 
       - `application_type = "Connector"`
-        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html.
+        - `application_class` defined with a plugin class name. All supported plugin class names are listed here: https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html.
           - For example: `application_class = "com.couchbase.connect.kafka.CouchbaseSinkConnector"`.
         - `type="SINK"` or `type="SOURCE"`
   4. `axual_application_principal` 
@@ -27,7 +27,7 @@ To create and start a connector application, we need these Axual Terraform resou
        - Updating `axual_application_deployment` stops the connector if it was running, updates the config, and starts it.
        - Deleting `axual_application_deployment` stops the connector if it was running, then deletes it.
 
-To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/Axual-Connect/developer/index-developer.html
+To read more about Connect Applications on Axual Platform: https://docs.axual.io/connect/developer/index-developer.html
 
 ### Example Resources:
 - When trying out this example, make sure to:

--- a/templates/resources/application_deployment.md.tmpl
+++ b/templates/resources/application_deployment.md.tmpl
@@ -4,11 +4,11 @@
 
 
 ## Usage
-- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connect/developer/connect-plugins-catalog/connect-plugins-catalog.html).
+- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html).
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
-- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connect/developer/starting-connectors.html).
+- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/developer/starting-connectors.html).
 - Currently, a data source for `axual_application_deployment` is not supported.
 
 ### Prerequisite: active Application Principal (Connector only)

--- a/templates/resources/application_deployment.md.tmpl
+++ b/templates/resources/application_deployment.md.tmpl
@@ -4,11 +4,11 @@
 
 
 ## Usage
-- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/developer/connect-plugins-catalog/connect-plugins-catalog.html).
+- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html).
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
-- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/developer/starting-connectors.html).
+- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connectstarting-connectors.html).
 - Currently, a data source for `axual_application_deployment` is not supported.
 
 ### Prerequisite: active Application Principal (Connector only)

--- a/templates/resources/application_deployment.md.tmpl
+++ b/templates/resources/application_deployment.md.tmpl
@@ -8,7 +8,7 @@
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.
-- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connectstarting-connectors.html).
+- For more information about connector applications in Axual, refer to the documentation: [Starting Connectors](https://docs.axual.io/connect/Axual-Connect/starting-connectors.html).
 - Currently, a data source for `axual_application_deployment` is not supported.
 
 ### Prerequisite: active Application Principal (Connector only)

--- a/templates/resources/application_deployment.md.tmpl
+++ b/templates/resources/application_deployment.md.tmpl
@@ -4,7 +4,7 @@
 
 
 ## Usage
-- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connectconnect-plugins-catalog/connect-plugins-catalog.html).
+- To see the required configuration parameters for each connect-plugin (`axual_application.application_class`), refer to the documentation: [Axual Connect Plugins Catalog](https://docs.axual.io/connect/Axual-Connect/connect-plugins-catalog/connect-plugins-catalog.html).
 - Creating the `axual_application_deployment` resource automatically starts the application.
 - Updating the `axual_application_deployment` resource automatically stops the application (if it is running), applies the update, and then restarts it.
 - Deleting the `axual_application_deployment` resource automatically stops the application (if it is running) before removing it.


### PR DESCRIPTION
## Summary

Two small maintenance changes:

1. **Fix Axual Connect documentation URLs** — Removed the obsolete `/developer/` path segment from all `docs.axual.io/connect/...` links. Correct structure is now `docs.axual.io/connect/Axual-Connect/...`. Applied across resource/data-source schema descriptions, generated docs, and source templates so they stay in sync.

2. **Update AVRO schema test namespace** — Changed test schema namespace from `io.axual.general` to `io.axual.qa.general` to match the QA environment, and updated the corresponding `full_name` assertions.

## Changes

### Docs / schema descriptions
- `internal/provider/data_source_application.go` — `application_class` description URL
- `internal/provider/resource_application.go` — `application_class` description URL
- `internal/provider/resource_application_deployment.go` — `configs` description URL
- `docs/resources/application.md`, `docs/resources/application_deployment.md`, `docs/guides/connector-application.md` — regenerated docs
- `templates/resources/application_deployment.md.tmpl`, `templates/guides/connector-application.md` — source templates

### Tests
- `internal/tests/SchemaVersionResource/avro-schemas/gitops_test_2_v1.avsc` — namespace `io.axual.general` → `io.axual.qa.general`
- `internal/tests/SchemaVersionResource/schema_version_resource_avro_test.go` — updated `full_name` assertions

## Notes
- Docs and templates kept in sync (no `go generate` drift).
- No functional changes to provider — docs and test fixtures only.